### PR TITLE
Fixed ELClient::Sync with type change that avoids a corrupting integer promotion

### DIFF
--- a/ELClient/ELClient.cpp
+++ b/ELClient/ELClient.cpp
@@ -68,7 +68,7 @@ ELClientPacket* ELClient::protoCompletedCb(void) {
 // Read all characters available on the serial input and process any messages that arrive, but
 // stop if a non-callback response comes in
 ELClientPacket *ELClient::Process() {
-  char value;
+  int value;
   while (_serial->available()) {
     value = _serial->read();
     if (value == SLIP_ESC) {


### PR DESCRIPTION
This fixes the Sync problem first reported here: https://gitter.im/jeelabs/esp-link?at=56b2ad0c958093bc12d19dc0

It may be compiler-dependent (I'm using Arduino.mk), but when comparing the read value in ELClient::Process, it was never equating to any of the SLIP_ defines. Changing its type to int (which is what Serial::available returns) solved the issue.

Signed-off-by: John Girouard john.girouard@gmail.com
