### PR TITLE
The 3rd argument of itoa is radix, not buffer length

### DIFF
--- a/ELClient/examples/mqtt/mqtt.ino
+++ b/ELClient/examples/mqtt/mqtt.ino
@@ -102,10 +102,10 @@ void loop() {
     Serial.println("publishing");
     char buf[12];
 
-    itoa(count++, buf, 11);
+    itoa(count++, buf, 10);
     mqtt.publish("/esp-link/1", buf);
 
-    itoa(count+99, buf, 11);
+    itoa(count+99, buf, 10);
     mqtt.publish("/rumah/pompa/pressureHead", buf);
 
     last = millis();


### PR DESCRIPTION
It appears that the 3rd argument of itoa was being used as a buffer length, but it is actually the radix. This fix now has the incrementing data show up in base 10 rather than base 11.

Signed-off-by: John Girouard john.girouard@gmail.com
